### PR TITLE
Fix build failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,5 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.3)
 
 set(CMAKE_PREFIX_PATH ${CMAKE_SYSROOT}/usr/lib/cmake)
-set(OE_QMAKE_PATH_EXTERNAL_HOST_BINS /usr/bin)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/conf.d/cmake/config.cmake)


### PR DESCRIPTION
CMake Error: The imported target "Qt5::Core" references the file
      "/usr/bin/qmake"
but this file does not exist.
You are using the submodule version of app-templates.
This version will not be update in the future and you should
migrate to the CMake module version.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>